### PR TITLE
Invert test

### DIFF
--- a/src/expect.js
+++ b/src/expect.js
@@ -1,88 +1,60 @@
-const { prettyPrint, areSameObjectProperties } = require('./utilities');
+const { prettyPrint, areSameObjectProperties } = require("./utilities");
 
 // expect(something).toBe(something2);
 
-function toBe(actualValue) {
-  return function (expectedValue) {
-    if (Object.is(expectedValue, actualValue)) {
-      console.log('✅');
-    } else {
-      console.error(
-        `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-          expectedValue,
-        )}`,
-      );
-    }
-  };
-}
-
-function toEqual(actualValue) {
-  return function (expectedValue) {
-    if (typeof expectedValue === 'object') {
-      if (areSameObjectProperties(expectedValue, actualValue)) {
-        console.log('✅');
-      } else {
-        console.error(
-          `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-            expectedValue,
-          )}`,
-        );
-      }
-    } else {
-      if (expectedValue == actualValue) {
-        console.log('✅');
-      } else {
-        console.error(
-          `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-            expectedValue,
-          )}`,
-        );
-      }
-    }
-  };
-}
-
 function expect(actualValue) {
-  return {
-    not: {
+  const functions = (invert) => {
+    return {
       toBe(expectedValue) {
-        if (!Object.is(expectedValue, actualValue)) {
-          console.log('✅');
+        let test = Object.is(expectedValue, actualValue);
+        if (invert) test = !test;
+
+        if (test) {
+          console.log("✅");
         } else {
           console.error(
             `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-              expectedValue,
-            )}`,
+              expectedValue
+            )}`
           );
         }
       },
       toEqual(expectedValue) {
-        if (typeof expectedValue === 'object') {
-          if (!areSameObjectProperties(expectedValue, actualValue)) {
-            console.log('✅');
+        let test;
+        if (typeof expectedValue === "object") {
+          test = areSameObjectProperties(expectedValue, actualValue);
+          if (invert) test = !test;
+
+          if (test) {
+            console.log("✅");
           } else {
             console.error(
               `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-                expectedValue,
-              )}`,
+                expectedValue
+              )}`
             );
           }
         } else {
-          if (expectedValue != actualValue) {
-            console.log('✅');
+          test = expectedValue == actualValue;
+          if (invert) test = !test;
+
+          if (test) {
+            console.log("✅");
           } else {
             console.error(
               `❌ expected ${prettyPrint(actualValue)} to equal ${prettyPrint(
-                expectedValue,
-              )}`,
+                expectedValue
+              )}`
             );
           }
         }
       },
-    },
-    toBe: toBe(actualValue),
-    toEqual: toEqual(actualValue),
+    };
   };
+
+  functions.not = functions(true);
+
+  return functions(false);
 }
 
 module.exports = {

--- a/src/expect.js
+++ b/src/expect.js
@@ -52,9 +52,10 @@ function expect(actualValue) {
     };
   };
 
-  functions.not = functions(true);
+  const object = functions(false)
+  object.not = functions(true);
 
-  return functions(false);
+  return object;
 }
 
 module.exports = {


### PR DESCRIPTION
The idea here is each test knows it can be inverted then with a .not the test moves to the inverted way.

The functions function will return an object, initially not is added but after not is called not isn't in the new inverted object.

If we wanted to really save on code (but also lose readability) we could do something like

```js
if (!!(invert ^ Object.is(expectedValue, actualValue))) {
  ...
}
```

But as I say you lose readability.

___

I hope you don't mind me suggesting this Nick it just came to me so it might have some catch I haven't thought of but in theory it means you can write future tests in a certain style and the not will automatically just work.

Like you could add

```js
toBeTruthy: () => {
  let test = !!expectedValue;
  if (invert) test = !test;
  
  if(test) {
    console.log("✅");
  } else {
    console.error( `❌ expected ${prettyPrint(expectedValue)} to truthy`);
  }
}
```

Which would mean miniExpect('cheese').toBeTruthy() and miniExpect(0).not.toBeTruthy() would both just work out the box.

`Note to self: don't rename a branch after you've done a pull request`